### PR TITLE
Fix README config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Fly application template for publishing fly logs to LogDNA
 # Usage
 
 ```
-fly secrets set TARGET_FLY_APP_NAME=yourapp LOGDNA_TOKEN=token FLY_TOKEN=token
+fly secrets set TARGET_FLY_APP_NAME=yourapp LOGDNA_TOKEN=token FLY_ACCESS_TOKEN=token
 fly deploy
 ```


### PR DESCRIPTION
The script to retrieve logs from Fly expects a `FLY_ACCESS_TOKEN` environment variable, but the README incorrectly shows configuring `FLY_TOKEN`.